### PR TITLE
Add Randomize Button to Input Forms and Extend Seed Randomization Functionality

### DIFF
--- a/app/constants.ts
+++ b/app/constants.ts
@@ -5,3 +5,5 @@ export const missingViewComfyFileError = `The ${viewComfyFileName} file is missi
 export const ComfyUIConnRefusedError = (comfyUrl: string) => {
     return `Cannot connect to ComfyUI using ${comfyUrl}, make sure that you have a ComfyUI instance running and that the URL is correct \nor you can change the ComfyUI URL in the .env file using the variables COMFYUI_API_URL and if you're using SSL/TLS set COMFYUI_SECURE to true`
 }
+
+export const SEED_LIKE_INPUT_VALUES = ["seed", "noise_seed", "rand_seed"];

--- a/app/models/comfy-workflow.ts
+++ b/app/models/comfy-workflow.ts
@@ -38,10 +38,26 @@ export class ComfyWorkflow {
                 obj[path[path.length - 1]] = input.value;
             }
         }
+
+        const newSeed = this.getNewSeed();
+
         for (const key in this.workflow) {
-            if (this.workflow[key].class_type === "SaveImage" || this.workflow[key].class_type === "VHS_VideoCombine") {
-                this.workflow[key].inputs.filename_prefix = this.getFileNamePrefix();
-            }
+            let node = this.workflow[key];
+            switch(node.class_type) {
+                case "SaveImage":
+                case "VHS_VideoCombine":
+                    node.inputs.filename_prefix = this.getFileNamePrefix();
+                    break;
+                    
+                case "KSampler":
+                case "RandomNoise":
+                default:
+                    Object.keys(node.inputs).forEach((key) => {
+                        if(["seed", "noise_seed", "rand_seed"].includes(key)) {
+                            node.inputs[key] = newSeed; 
+                        }                        
+                    });
+            }            
         }
     }
 
@@ -59,6 +75,12 @@ export class ComfyWorkflow {
 
     public getFileNamePrefix() {
         return `${this.id}_`;
+    }
+
+    public getNewSeed() {
+        const minCeiled = Math.ceil(0);
+        const maxFloored = Math.floor(2**32);
+        return Math.floor(Math.random() * (maxFloored - minCeiled + 1) + minCeiled); 
     }
 
     private async createFileFromInput(file: File) {

--- a/app/models/comfy-workflow.ts
+++ b/app/models/comfy-workflow.ts
@@ -49,8 +49,6 @@ export class ComfyWorkflow {
                     node.inputs.filename_prefix = this.getFileNamePrefix();
                     break;
                     
-                case "KSampler":
-                case "RandomNoise":
                 default:
                     Object.keys(node.inputs).forEach((key) => {
                         if(["seed", "noise_seed", "rand_seed"].includes(key)) {

--- a/app/models/comfy-workflow.ts
+++ b/app/models/comfy-workflow.ts
@@ -51,9 +51,12 @@ export class ComfyWorkflow {
                     
                 default:
                     Object.keys(node.inputs).forEach((key) => {
-                        if(["seed", "noise_seed", "rand_seed"].includes(key)) {
+                        if(
+                            ["seed", "noise_seed", "rand_seed"].includes(key) 
+                            && typeof node.inputs[key] === 'string'
+                            && node.inputs[key]?.replace(/\s/g, "").toLowerCase() == 'randomize') {
                             node.inputs[key] = newSeed; 
-                        }                        
+                        }                    
                     });
             }            
         }

--- a/components/view-comfy/view-comfy-form.tsx
+++ b/components/view-comfy/view-comfy-form.tsx
@@ -29,6 +29,7 @@ import {
     CollapsibleTrigger,
 } from "@/components/ui/collapsible"
 import { useState, useEffect } from "react";
+import { RefreshCw } from "lucide-react";
 
 interface IInputForm extends IInputField {
     id: string;
@@ -255,10 +256,96 @@ function InputFieldToUI(args: { input: IInputForm, field: any, editMode?: boolea
             <FormMediaInput input={input} field={field} editMode={editMode} remove={remove} index={index} />
         )
     }
+    
+    if (input.valueType === "seed" ) {
+        return (
+            <FormSeedInput input={input} field={field} editMode={editMode} remove={remove} index={index} />
+        )
+    }
 
     return (
         <FormBasicInput input={input} field={field} editMode={editMode} remove={remove} index={index} />
     )
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function FormSeedInput(args: { input: IInputForm, field: any, editMode?: boolean, remove?: UseFieldArrayRemove, index: number }) {
+    const { input, field, editMode, remove, index } = args;
+
+    const [isRandomized, setIsRandomized] = useState(false); // State to manage checkbox behavior
+    const [storedValue, setStoredValue] = useState(field.value); // State to preserve input value
+
+    const toggleRandomize = () => {
+        const newValue = !isRandomized;
+        setIsRandomized(newValue);
+        if (newValue) {
+            // Save the current input value before disabling it
+            setStoredValue(field.value);
+            field.onChange("randomize");
+        } else {
+            // Restore the saved value when reactivating the input
+            field.onChange(storedValue);
+        }
+    };
+
+    return (
+        <FormItem key={input.id}>
+            <FormLabel className={FORM_STYLE.label}>
+                {input.title}
+                {editMode && (
+                    <Button
+                        size="icon"
+                        variant="ghost"
+                        className="text-muted-foreground"
+                        onClick={remove ? () => remove(index) : undefined}
+                    >
+                        <Trash2 className="size-5" />
+                    </Button>
+                )}
+            </FormLabel>
+            <FormControl>
+                <div className="flex items-center space-x-2">
+                    <Input
+                        placeholder={input.placeholder}
+                        {...field}
+                        type="number"
+                        disabled={isRandomized} // Disable input if checkbox is checked
+                        value={isRandomized ? "randomize" : field.value} // Display "randomize" if checkbox is checked
+                        onChange={(e) => {
+                            const value = e.target.value;
+                            if (!isRandomized) {
+                                setStoredValue(value); // Update stored value when input changes
+                                field.onChange(value);
+                            }
+                        }}
+                        className="flex-1"
+                    />
+                    {/* Hidden checkbox */}
+                    <Checkbox
+                        className="hidden"
+                        checked={isRandomized}
+                        onCheckedChange={() => {}}
+                    />
+                    {/* Randomize button */}
+                    <button
+                        type="button"
+                        title={isRandomized ? "Disable randomization" : "Enable randomization"}
+                        onClick={toggleRandomize}
+                        className={`p-2 rounded-md ${
+                            isRandomized ? "text-blue-500" : "text-gray-400"
+                        } hover:text-blue-600`}
+                    >
+                        <RefreshCw className="w-5 h-5" />
+                    </button>
+                </div>
+            </FormControl>
+            {input.helpText !== "Helper Text" && (
+                <FormDescription>
+                    {input.helpText}
+                </FormDescription>
+            )}
+        </FormItem>
+    );
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,9 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function getComfyUIRandomSeed() {
+  const minCeiled = Math.ceil(0);
+  const maxFloored = Math.floor(2 ** 32);
+  return Math.floor(Math.random() * (maxFloored - minCeiled + 1) + minCeiled);
+}

--- a/lib/workflow-api-parser.ts
+++ b/lib/workflow-api-parser.ts
@@ -1,3 +1,4 @@
+import { SEED_LIKE_INPUT_VALUES } from "@/app/constants";
 import type { IViewComfyBase } from "@/app/providers/view-comfy-provider";
 
 export interface IInputField {
@@ -7,7 +8,7 @@ export interface IInputField {
     value: any;
     workflowPath: string[];
     helpText?: string;
-    valueType: InputValueType | "long-text" | "video";
+    valueType: InputValueType | "long-text" | "video" | "seed" | "noise_seed" | "rand_seed";
     validations: { required: boolean };
     key: string;
 }
@@ -41,7 +42,7 @@ export function workflowAPItoViewComfy(source: WorkflowApiJSON): IViewComfyBase 
             }
         }
         try {
-            
+
             switch (value.class_type) {
 
                 case 'CLIPTextEncode':
@@ -57,7 +58,7 @@ export function workflowAPItoViewComfy(source: WorkflowApiJSON): IViewComfyBase 
                         });
                     }
                     break;
-                    
+
                 case "LoadImage":
                 case "LoadImageMask":
                     const uploadInput = inputs.find(input => input.title === "Upload");
@@ -90,16 +91,12 @@ export function workflowAPItoViewComfy(source: WorkflowApiJSON): IViewComfyBase 
 
                 default:
 
-                    Object.keys(inputs).forEach((key) => {
-                        switch(inputs[key].title.toLowerCase()) {
-                            case "seed":
-                            case "noise_seed":
-                            case "rand_seed":
-                                inputs[key].valueType = "seed";
-                                break;
+                    for (const input of inputs) {
+                        if (SEED_LIKE_INPUT_VALUES.includes(input.title.toLowerCase())) {
+                            input.valueType = "seed";
                         }
-                    });
-                   
+                    }
+
                     if (inputs.length > 0) {
                         advancedInputs.push({
                             title: getTitleFromValue(value.class_type, value),
@@ -108,7 +105,7 @@ export function workflowAPItoViewComfy(source: WorkflowApiJSON): IViewComfyBase 
                         });
                     }
                     break;
-            }            
+            }
 
         } catch (e) {
             console.log("Error", e);

--- a/lib/workflow-api-parser.ts
+++ b/lib/workflow-api-parser.ts
@@ -41,50 +41,75 @@ export function workflowAPItoViewComfy(source: WorkflowApiJSON): IViewComfyBase 
             }
         }
         try {
-            if (value.class_type === 'CLIPTextEncode') {
-                if (inputs.length > 0) {
-                    const input = inputs[0];
-                    input.valueType = "long-text";
-                    input.title = getTitleFromValue(value.class_type, value);
-                    input.placeholder = getTitleFromValue(value.class_type, value);
+            
+            switch (value.class_type) {
+
+                case 'CLIPTextEncode':
+                    if (inputs.length > 0) {
+                        const input = inputs[0];
+                        input.valueType = "long-text";
+                        input.title = getTitleFromValue(value.class_type, value);
+                        input.placeholder = getTitleFromValue(value.class_type, value);
+                        basicInputs.push({
+                            title: getTitleFromValue(value.class_type, value),
+                            inputs: inputs,
+                            key: `${key}-${value.class_type}`
+                        });
+                    }
+                    break;
+                    
+                case "LoadImage":
+                case "LoadImageMask":
+                    const uploadInput = inputs.find(input => input.title === "Upload");
+                    if (uploadInput) {
+                        const input = inputs[0];
+                        input.valueType = "image";
+                        input.title = getTitleFromValue(value.class_type, value);
+                        input.placeholder = getTitleFromValue(value.class_type, value);
+                        input.value = null;
+                        basicInputs.push({
+                            title: getTitleFromValue(value.class_type, value),
+                            inputs: [input],
+                            key: `${key}-${value.class_type}`
+                        });
+                    }
+                    break;
+
+                case "VHS_LoadVideo":
+                    const uploadInputIndex = inputs.findIndex(input => input.title === "Video");
+                    if (typeof uploadInputIndex !== "undefined") {
+                        inputs[uploadInputIndex].valueType = "video"
+                        inputs[uploadInputIndex].value = null
+                    }
                     basicInputs.push({
                         title: getTitleFromValue(value.class_type, value),
                         inputs: inputs,
                         key: `${key}-${value.class_type}`
                     });
-                }
-            } else if (value.class_type === "LoadImage" || value.class_type === "LoadImageMask") {
-                const uploadInput = inputs.find(input => input.title === "Upload");
-                if (uploadInput) {
-                    const input = inputs[0];
-                    input.valueType = "image";
-                    input.title = getTitleFromValue(value.class_type, value);
-                    input.placeholder = getTitleFromValue(value.class_type, value);
-                    input.value = null;
-                    basicInputs.push({
-                        title: getTitleFromValue(value.class_type, value),
-                        inputs: [input],
-                        key: `${key}-${value.class_type}`
+                    break;
+
+                default:
+
+                    Object.keys(inputs).forEach((key) => {
+                        switch(inputs[key].title.toLowerCase()) {
+                            case "seed":
+                            case "noise_seed":
+                            case "rand_seed":
+                                inputs[key].valueType = "seed";
+                                break;
+                        }
                     });
-                }
-            } else if (value.class_type === "VHS_LoadVideo") {
-                const uploadInputIndex = inputs.findIndex(input => input.title === "Video");
-                if (typeof uploadInputIndex !== "undefined") {
-                    inputs[uploadInputIndex].valueType = "video"
-                    inputs[uploadInputIndex].value = null
-                }
-                basicInputs.push({
-                    title: getTitleFromValue(value.class_type, value),
-                    inputs: inputs,
-                    key: `${key}-${value.class_type}`
-                });
-            } else if (inputs.length > 0) {
-                advancedInputs.push({
-                    title: getTitleFromValue(value.class_type, value),
-                    inputs: inputs,
-                    key: `${key}-${value.class_type}`
-                });
-            }
+                   
+                    if (inputs.length > 0) {
+                        advancedInputs.push({
+                            title: getTitleFromValue(value.class_type, value),
+                            inputs: inputs,
+                            key: `${key}-${value.class_type}`
+                        });
+                    }
+                    break;
+            }            
+
         } catch (e) {
             console.log("Error", e);
         }

--- a/pages/playground/playground-page.tsx
+++ b/pages/playground/playground-page.tsx
@@ -10,7 +10,7 @@ import {
     DrawerContent,
     DrawerTrigger,
 } from "@/components/ui/drawer"
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { Header } from "@/components/header";
 import { PlaygroundForm } from "./playground-form";
 import { Loader } from "@/components/loader";
@@ -203,9 +203,9 @@ function PlaygroundPageContent() {
                                     <div className="flex flex-col w-full h-full">
                                         {Object.entries(results).map(([timestamp, generation], index, array) => (
                                             <div className="flex flex-col gap-4 w-full h-full" key={timestamp}>
-                                                <div className="flex flex-wrap w-full h-full gap-4">
+                                                <div className="flex flex-wrap w-full h-full gap-4" key={timestamp}>
                                                     {generation.map((output) => (
-                                                        <>
+                                                        <Fragment key={output.url}>
                                                             <div
                                                                 key={output.url}
                                                                 className="flex items-center justify-center px-4 sm:w-[calc(50%-1rem)] lg:w-[calc(33.333%-1rem)]"
@@ -245,7 +245,7 @@ function PlaygroundPageContent() {
                                                                     )}
                                                                 </pre>
                                                             )}
-                                                        </>
+                                                        </Fragment>
                                                     ))}
                                                 </div>
                                                 <hr className={
@@ -273,3 +273,5 @@ export function PlaygroundPage() {
         <PlaygroundPageContent />
     );
 }
+
+


### PR DESCRIPTION
## Description:
This pull request introduces a UI enhancement and extends the functionality of seed randomization for various node types. 

## UI Enhancement:

Added a "Randomize" button next to input fields in the form UI. 
Clicking the button:

- Disables/enables the associated input field, preventing manual editing.

- The implementation is visually demonstrated in the attached image.

![image](https://github.com/user-attachments/assets/9e80671f-e4ce-4eaa-983f-b3579cb59071)
![image](https://github.com/user-attachments/assets/0c5cdc04-2e04-4574-9caa-be7bdfc76e6c)

## Extended Functionality:

The feature now supports seed randomization for all node types, not just KSampler.
The logic identifies seed-related input keys (["seed", "noise_seed", "rand_seed"]) in any node. 

## Behavioral Changes:

When the "Randomize" button is used, the input field becomes disabled to indicate that the value is now auto-generated. Users can re-enable the input by clicking on the same button.